### PR TITLE
Don't stall on OTHER_SPEED_CONFIGURATION requests

### DIFF
--- a/soc/nxp/usb/setup.go
+++ b/soc/nxp/usb/setup.go
@@ -113,6 +113,12 @@ func (hw *USB) getDescriptor(setup *SetupData) (err error) {
 		}
 	case DEVICE_QUALIFIER:
 		err = hw.tx(0, hw.Device.Qualifier.Bytes())
+	case OTHER_SPEED_CONFIGURATION: // Win10+ requests this
+		var conf []byte
+		if conf, err = dev.Configuration(index); err == nil {
+			conf[1] = OTHER_SPEED_CONFIGURATION // adjust descriptor type
+			err = hw.tx(0, false, trim(conf, setup.Length))
+		}
 	default:
 		hw.stall(0, IN)
 		err = fmt.Errorf("unsupported descriptor type: %#x", bDescriptorType)


### PR DESCRIPTION
Win10+ requests the OTHER_SPEED_CONFIGURATION descriptor. This fix prevents USBArmory from stalling after such a request. The default configuration descriptor is re-used and adjusted as OTHER_SPEED_CONFIGURATION response.