### PR TITLE
add idle time reporting

### DIFF
--- a/arm/arm.go
+++ b/arm/arm.go
@@ -64,6 +64,9 @@ type CPU struct {
 
 	// vector base address register
 	vbar uint32
+
+	// see [CPU.Idle] and [CPU.IdleTime]
+	idle uint64
 }
 
 // defined in arm.s

--- a/arm/timer.go
+++ b/arm/timer.go
@@ -120,3 +120,16 @@ func (cpu *CPU) SetAlarm(ns int64) {
 
 	write_cntptval(uint32(cnt), true)
 }
+
+// Idle suspends execution until an interrupt is received tracking idle time
+// for reporting by [CPU.IdleTime].
+func (cpu *CPU) Idle() {
+	start := read_cntpct()
+	wfi()
+	cpu.idle += read_cntpct() - start
+}
+
+// IdleTime returns the cumulative time spent halted, in nanoseconds. along
+func (cpu *CPU) IdleTime() int64 {
+	return int64(float64(cpu.idle) * cpu.TimerMultiplier)
+}

--- a/arm64/arm64.go
+++ b/arm64/arm64.go
@@ -28,6 +28,9 @@ type CPU struct {
 	TimerMultiplier float64
 	// Timer offset in nanoseconds
 	TimerOffset int64
+
+	// see [CPU.Idle] and [CPU.IdleTime]
+	idle uint64
 }
 
 // defined in arm64.s

--- a/arm64/timer.go
+++ b/arm64/timer.go
@@ -106,3 +106,16 @@ func (cpu *CPU) SetAlarm(ns int64) {
 
 	write_cntptval(uint32(cnt), true)
 }
+
+// Idle suspends execution until an interrupt is received tracking idle time
+// for reporting by [CPU.IdleTime].
+func (cpu *CPU) Idle() {
+	start := read_cntpct()
+	wfi()
+	cpu.idle += read_cntpct() - start
+}
+
+// IdleTime returns the cumulative time spent halted, in nanoseconds. along
+func (cpu *CPU) IdleTime() int64 {
+	return int64(float64(cpu.idle) * cpu.TimerMultiplier)
+}

--- a/loong64/loong64.go
+++ b/loong64/loong64.go
@@ -36,6 +36,9 @@ type CPU struct {
 	TimerMultiplier float64
 	// Timer offset in nanoseconds
 	TimerOffset int64
+
+	// see [CPU.Idle] and [CPU.IdleTime]
+	idle uint64
 }
 
 // defined in loong64.s

--- a/loong64/timer.go
+++ b/loong64/timer.go
@@ -95,3 +95,16 @@ func (cpu *CPU) SetTimer(ns int64, periodic bool) {
 func (cpu *CPU) ClearTimerInterrupt() {
 	write_ticlr(1)
 }
+
+// Idle suspends execution until an interrupt is received tracking idle time
+// for reporting by [CPU.IdleTime].
+func (cpu *CPU) Idle() {
+	start := cpu.Counter()
+	idle()
+	cpu.idle += cpu.Counter() - start
+}
+
+// IdleTime returns the cumulative time spent halted, in nanoseconds. along
+func (cpu *CPU) IdleTime() int64 {
+	return int64(float64(cpu.idle) * cpu.TimerMultiplier)
+}


### PR DESCRIPTION
This patch adds idle time reporting for single-core platforms, to aid `top` like reporting.