### PR TITLE
flexcom: avoid deferred unlock during early init

### DIFF
--- a/soc/microchip/flexcom/flexcom.go
+++ b/soc/microchip/flexcom/flexcom.go
@@ -59,9 +59,9 @@ func (hw *FLEXCOM) mode(n int) {
 // mode, this is mutually exclusive with other modes.
 func (hw *FLEXCOM) InitUSART() {
 	hw.Lock()
-	defer hw.Unlock()
 
 	if hw.Base == 0 {
+		hw.Unlock()
 		panic("invalid FLEXCOM controller instance")
 	}
 
@@ -82,6 +82,9 @@ func (hw *FLEXCOM) InitUSART() {
 	hw.USART.fmr = hw.Base + FLEX_USART_OFFSET + FLEX_US_FMR
 
 	hw.USART.init()
+
+	// Hwinit1 runs on the system stack.
+	hw.Unlock()
 }
 
 // InitTWI initializes and enables a FLEXCOM controller in TWI initiator mode,

--- a/soc/microchip/flexcom/flexcom.go
+++ b/soc/microchip/flexcom/flexcom.go
@@ -61,7 +61,6 @@ func (hw *FLEXCOM) InitUSART() {
 	hw.Lock()
 
 	if hw.Base == 0 {
-		hw.Unlock()
 		panic("invalid FLEXCOM controller instance")
 	}
 
@@ -83,7 +82,7 @@ func (hw *FLEXCOM) InitUSART() {
 
 	hw.USART.init()
 
-	// Hwinit1 runs on the system stack.
+	// no defer as goos.Hwinit1 might call us from system stack
 	hw.Unlock()
 }
 


### PR DESCRIPTION
InitUSART runs from Hwinit1 on the runtime system stack. Debug builds with optimization disabled lower its deferred unlock to runtime.deferprocStack, which aborts with "defer on system stack" before the console banner.

Unlock explicitly so early initialization behaves independently of compiler optimization. A JTAG-staged debug runtime reported its exact identity on LAN969x hardware after this change.