### PR TITLE
fix RPMB reliable write block count

### DIFF
--- a/soc/nxp/usdhc/mmc.go
+++ b/soc/nxp/usdhc/mmc.go
@@ -374,14 +374,13 @@ func (hw *USDHC) transferRPMB(dtd int, buf []byte, rel bool) (err error) {
 
 	defer func() {
 		hw.rpmb = false
+		hw.rel = false
 		hw.Unlock()
 	}()
 
 	if dtd == WRITE {
-		if rel {
-			// reliable write request
-			bits.Set(&blocks, 31)
-		}
+		// reliable write request
+		hw.rel = rel
 
 		// CMD25 - WRITE_MULTIPLE_BLOCK - write consecutive blocks
 		err = hw.transfer(25, WRITE, 0, blocks, 512, buf)

--- a/soc/nxp/usdhc/usdhc.go
+++ b/soc/nxp/usdhc/usdhc.go
@@ -278,6 +278,8 @@ type USDHC struct {
 
 	// eMMC Replay Protected Memory Block (RPMB) operation
 	rpmb bool
+	// eMMC RPMB reliable write request
+	rel bool
 
 	readTimeout  time.Duration
 	writeTimeout time.Duration
@@ -547,8 +549,15 @@ func (hw *USDHC) transfer(index uint32, dtd uint32, arg uint64, blocks uint32, b
 			return
 		}
 
+		cmd23Arg := blocks
+
+		if hw.rel {
+			// reliable write request
+			bits.Set(&cmd23Arg, 31)
+		}
+
 		// CMD23 - SET_BLOCK_COUNT - define read/write block count
-		if err = hw.cmd(23, blocks, 0, 0); err != nil {
+		if err = hw.cmd(23, cmd23Arg, 0, 0); err != nil {
 			return
 		}
 


### PR DESCRIPTION
:wave: Hi there,

I bumped into an MMC bug while writing some Tamago code for the USB Armory MK II RPMB. I'm reasonably confident I identified the correct bug, and I'm _mostly_ confident in my proposed fix. I wouldn't be offended if you took this as just a bug report and devised your own fix & tests :-)

[`WriteRPMB(buf, true)`](https://github.com/usbarmory/tamago/blob/031bf035142af992c0c042e5cdfdcc1bdb3db0dc/soc/nxp/usdhc/mmc.go#L399-L401) encodes the RPMB reliable-write request by setting bit 31 of the blocks value it passes to [`USDHC.transfer()`](https://github.com/usbarmory/tamago/blob/031bf035142af992c0c042e5cdfdcc1bdb3db0dc/soc/nxp/usdhc/mmc.go#L380-L391) (`0x80000001` for a single frame). However, as of 549b0c19 the transfer size check rejects the encoded value, so every reliable RPMB write failed with "transfer size cannot exceed 65535 blocks" before any command reached the card. 

Since bit 31 is a flag of the `CMD23` `SET_BLOCK_COUNT` argument, not part of the block count this commit reworks the code to track the request in a dedicated flag alongside the existing rpmb one. It's set only when composing the `CMD23` argument, so that blocks remains an actual count for range validation, `BLK_ATT.BLKCNT`, timeout scaling and the data command. I think this closer matches what Linux does in `mmc/core/block.c` and and [`mmc/ioctl.h`](https://github.com/torvalds/linux/blob/cf62c7084acfa9f1ef98ce81b38c934c7ea10f93/include/uapi/linux/mmc/ioctl.h#L6-L51).

I believe before 549b0c19 the encoding only worked by accident: the check introduced in db7a8adf (`(blocks & 0xffff) > 0xffff`) can never be true, and `reg.SetN` happened to mask bit 31 out of `BLK_ATT.BLKCNT`, while the write timeout was still scaled by the encoded value instead of 1.