### PR TITLE
lan8804: wait for reset completion

### DIFF
--- a/phy/microchip/lan8804/phy.go
+++ b/phy/microchip/lan8804/phy.go
@@ -157,7 +157,7 @@ func (hw *PHY) Reset() (err error) {
 			return
 		}
 
-		if bits.Get16(&control, CTRL_RESET) {
+		if !bits.Get16(&control, CTRL_RESET) {
 			return
 		}
 


### PR DESCRIPTION
The basic control reset bit remains set while reset is in progress and clears when the PHY completes the operation. Waiting for the set state returned immediately and allowed initialization to continue before reset completed.

Wait for the bit to clear. This restores copper PHY initialization and link establishment on Tactical 1000 hardware.