### PR TITLE
lan9696evb: initialize USART0 from constants

### DIFF
--- a/board/microchip/lan9696evb/lan9696evb.go
+++ b/board/microchip/lan9696evb/lan9696evb.go
@@ -24,9 +24,9 @@ import (
 // Peripheral instances
 var (
 	USART0 = &flexcom.USART{
-		Index: lan969x.FLEXCOM0.Index,
-		Base:  lan969x.FLEXCOM0.Base,
-		IRQ:   lan969x.FLEXCOM0.IRQ,
+		Index: 1,
+		Base:  lan969x.FLEXCOM0_BASE,
+		IRQ:   lan969x.FLEXCOM0_IRQ,
 	}
 )
 


### PR DESCRIPTION
runtime/goos.Hwinit1 runs before package initialization. Reading fields from lan969x.FLEXCOM0 makes the USART0 initializer dynamic, so early runtime setup can call USART0.Init while USART0 still has its zero value.

Use the controller index, base, and IRQ constants so the linker emits the USART instance as static data before Hwinit1 runs.