### PR TITLE
gic: fix DisableInterrupt disabling all enabled interrupts

### DIFF
--- a/arm/gic/gic.go
+++ b/arm/gic/gic.go
@@ -135,7 +135,9 @@ func (hw *GIC) irq(m int, enable bool) {
 		addr += GICD_ICENABLER
 	}
 
-	reg.SetTo(addr+4*n, i, true)
+	// ISENABLER and ICENABLER are write-1-to-act, a read-modify-write would
+	// act on every other set bit as well.
+	reg.Write(addr+4*n, 1<<i)
 }
 
 // EnableInterrupt enables forwarding of the corresponding interrupt to the CPU


### PR DESCRIPTION
`DisableInterrupt` disables every enabled interrupt, not the one requested.
`EnableInterrupt` has the same shape and is masked only by usually being called
on an already-quiet distributor.

`irq()` reaches `GICD_ISENABLER` / `GICD_ICENABLER` through `reg.SetTo`, which is
a read-modify-write. Both registers are write-1-to-act, and reading either
returns the current *enable mask* — so the read returns every enabled interrupt
and writing that value back acts on all of them.

Writing only the requested bit is correct for both, since a zero has no effect on
these registers.

`soc/nxp/imx6ul` and `soc/microchip/lan969x` both use this driver today.

Verified on a GIC-400: with SPI 97 and 99 both enabled, disabling 97 now leaves
99 delivering. Previously it silenced both.

Found while bringing up a BCM2711 target, which is the subject of #101 — this
part stands alone and does not depend on any of that work.
